### PR TITLE
Fix README.md spelling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Require:
 sudo apt install build-essential git cmake
 ```
 
-### Unbuntu
+### Ubuntu
 
 ```bash
 sudo apt install libasound2-dev mesa-common-dev libx11-dev libxrandr-dev libxi-dev xorg-dev libgl1-mesa-dev libglu1-mesa-dev


### PR DESCRIPTION
*Ubuntu* was spelled wrong as *Unbuntu*